### PR TITLE
Check Firmata firmware before flashing

### DIFF
--- a/lv/liveview-electron.js
+++ b/lv/liveview-electron.js
@@ -244,6 +244,7 @@ function initBoard(){
 		rebuildSlots();
 		
 		console.log('%cBoard is ready to go 🚀','color: '+consoleColors.good+';');
+		console.log('Firmata Version', `${board.io.firmware.version.major}.${board.io.firmware.version.minor}`);
 
 		reattachAllSlots();
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://blokdots.com",
   "dependencies": {
-    "avrgirl-arduino": "github:ajfisher/avrgirl-arduino#update-sp-6",
+    "avrgirl-arduino": "^3.0.0",
     "electron-is-dev": "^0.3.0",
     "electron-window-state": "^5.0.1",
     "johnny-five": "^1.0.0",


### PR DESCRIPTION
Currently the Firmata firmware is always flashed onto the Arduino, which takes time and can also lead to occasional flashing errors.

With this PR, we try to open the board first and only if that fails (and thus we assume that Firmata is not flashed), we try to flash the firmware onto the board.

(We also update AVRGirl-Arduino to version 3, as the SerialPort Version 6 is now merged in.)